### PR TITLE
Output structured comments for build events

### DIFF
--- a/homu/comments.py
+++ b/homu/comments.py
@@ -1,0 +1,83 @@
+import json
+
+
+class Comment:
+    def __init__(self, **args):
+        if len(args) != len(self.params):
+            raise KeyError("different number of params")
+        for key, value in args.items():
+            if key in self.params:
+                setattr(self, key, value)
+            else:
+                raise KeyError("unknown attribute: %s" % key)
+
+    def jsonify(self):
+        out = {"type": self.__class__.__name__}
+        for param in self.params:
+            out[param] = getattr(self, param)
+        return json.dumps(out, separators=(',', ':'))
+
+
+class BuildStarted(Comment):
+    params = ["head_sha", "merge_sha"]
+
+    def render(self):
+        return ":hourglass: Testing commit %s with merge %s..." % (
+            self.head_sha, self.merge_sha,
+        )
+
+
+class TryBuildStarted(Comment):
+    params = ["head_sha", "merge_sha"]
+
+    def render(self):
+        return ":hourglass: Trying commit %s with merge %s..." % (
+            self.head_sha, self.merge_sha,
+        )
+
+
+class BuildCompleted(Comment):
+    params = ["approved_by", "base_ref", "builders", "merge_sha"]
+
+    def render(self):
+        urls = ", ".join(
+            "[%s](%s)" % kv for kv in sorted(self.builders.items())
+        )
+        return (
+            ":sunny: Test successful - %s\n"
+            "Approved by: %s\n"
+            "Pushing %s to %s..."
+            % (
+                urls, self.approved_by, self.merge_sha, self.base_ref,
+            )
+        )
+
+
+class TryBuildCompleted(Comment):
+    params = ["builders", "merge_sha"]
+
+    def render(self):
+        urls = ", ".join(
+            "[%s](%s)" % kv for kv in sorted(self.builders.items())
+        )
+        return ":sunny: Try build successful - %s\nBuild commit: %s" % (
+            urls, self.merge_sha,
+        )
+
+
+class BuildFailed(Comment):
+    params = ["builder_url", "builder_name"]
+
+    def render(self):
+        return ":broken_heart: Test failed - [%s](%s)" % (
+            self.builder_name, self.builder_url
+        )
+
+
+class TryBuildFailed(Comment):
+    params = ["builder_url", "builder_name"]
+
+    def render(self):
+        return ":broken_heart: Test failed - [%s](%s)" % (
+            self.builder_name, self.builder_url
+        )

--- a/homu/comments.py
+++ b/homu/comments.py
@@ -81,3 +81,10 @@ class TryBuildFailed(Comment):
         return ":broken_heart: Test failed - [%s](%s)" % (
             self.builder_name, self.builder_url
         )
+
+
+class TimedOut(Comment):
+    params = []
+
+    def render(self):
+        return ":boom: Test timed out"

--- a/homu/main.py
+++ b/homu/main.py
@@ -367,15 +367,14 @@ class PullReqState:
         self.save()
         self.set_status('failure')
 
-        desc = 'Test timed out'
         utils.github_create_status(
             self.get_repo(),
             self.head_sha,
             'failure',
             '',
-            desc,
+            'Test timed out',
             context='homu')
-        self.add_comment(':boom: {}'.format(desc))
+        self.add_comment(comments.TimedOut())
         self.change_labels(LabelEvent.TIMED_OUT)
 
 

--- a/homu/main.py
+++ b/homu/main.py
@@ -179,7 +179,7 @@ class PullReqState:
         return issue
 
     def add_comment(self, comment):
-        if issubclass(comment.__class__, comments.Comment):
+        if isinstance(comment, comments.Comment):
             comment = "%s\n<!-- homu: %s -->" % (
                 comment.render(), comment.jsonify(),
             )

--- a/homu/main.py
+++ b/homu/main.py
@@ -1245,7 +1245,7 @@ def start_build(state, repo_cfgs, buildbot_slots, logger, db, git_cfg):
         builders += ['checks-' + key for key, value in repo_cfg['checks'].items() if 'name' in value]  # noqa
         only_status_builders = False
 
-    if len(builders) is 0:
+    if len(builders) == 0:
         raise RuntimeError('Invalid configuration')
 
     lazy_debug(logger, lambda: "start_build: builders={!r}".format(builders))
@@ -1699,7 +1699,7 @@ def main():
                     builders += ['status-' + key for key, value in repo_cfg['status'].items() if 'context' in value]  # noqa
                 if 'checks' in repo_cfg:
                     builders += ['checks-' + key for key, value in repo_cfg['checks'].items() if 'name' in value]  # noqa
-                if len(builders) is 0:
+                if len(builders) == 0:
                     raise RuntimeError('Invalid configuration')
 
                 state.init_build_res(builders, use_db=False)

--- a/homu/server.py
+++ b/homu/server.py
@@ -568,9 +568,7 @@ def report_build_res(succ, url, builder, state, logger, repo_cfg):
                 state.add_comment(comments.BuildCompleted(
                     approved_by=state.approved_by,
                     base_ref=state.base_ref,
-                    builders=dict(
-                        (k, v["url"]) for k, v in state.build_res.items()
-                    ),
+                    builders={k: v["url"] for k, v in state.build_res.items()},
                     merge_sha=state.merge_sha,
                 ))
                 state.change_labels(LabelEvent.SUCCEED)
@@ -601,9 +599,7 @@ def report_build_res(succ, url, builder, state, logger, repo_cfg):
                     state.add_comment(':eyes: ' + desc)
             else:
                 state.add_comment(comments.TryBuildCompleted(
-                    builders=dict(
-                        (k, v["url"]) for k, v in state.build_res.items()
-                    ),
+                    builders={k: v["url"] for k, v in state.build_res.items()},
                     merge_sha=state.merge_sha,
                 ))
                 state.change_labels(LabelEvent.TRY_SUCCEED)

--- a/homu/server.py
+++ b/homu/server.py
@@ -9,6 +9,7 @@ from .main import (
     synchronize,
     LabelEvent,
 )
+from . import comments
 from . import utils
 from .utils import lazy_debug
 import github3
@@ -558,19 +559,20 @@ def report_build_res(succ, url, builder, state, logger, repo_cfg):
     if succ:
         if all(x['res'] for x in state.build_res.values()):
             state.set_status('success')
-            desc = 'Test successful'
-            utils.github_create_status(state.get_repo(), state.head_sha,
-                                       'success', url, desc, context='homu')
-
-            urls = ', '.join('[{}]({})'.format(builder, x['url']) for builder, x in sorted(state.build_res.items()))  # noqa
-            test_comment = ':sunny: {} - {}'.format(desc, urls)
+            utils.github_create_status(
+                state.get_repo(), state.head_sha,
+                'success', url, "Test successful", context='homu'
+            )
 
             if state.approved_by and not state.try_:
-                comment = (test_comment + '\n' +
-                           'Approved by: {}\nPushing {} to {}...'
-                           ).format(state.approved_by, state.merge_sha,
-                                    state.base_ref)
-                state.add_comment(comment)
+                state.add_comment(comments.BuildCompleted(
+                    approved_by=state.approved_by,
+                    base_ref=state.base_ref,
+                    builders=dict(
+                        (k, v["url"]) for k, v in state.build_res.items()
+                    ),
+                    merge_sha=state.merge_sha,
+                ))
                 state.change_labels(LabelEvent.SUCCEED)
                 try:
                     try:
@@ -598,24 +600,34 @@ def report_build_res(succ, url, builder, state, logger, repo_cfg):
 
                     state.add_comment(':eyes: ' + desc)
             else:
-                comment = (test_comment + '\n' +
-                           'State: approved={} try={}'
-                           ).format(state.approved_by, state.try_)
-                state.add_comment(comment)
+                state.add_comment(comments.TryBuildCompleted(
+                    builders=dict(
+                        (k, v["url"]) for k, v in state.build_res.items()
+                    ),
+                    merge_sha=state.merge_sha,
+                ))
                 state.change_labels(LabelEvent.TRY_SUCCEED)
 
     else:
         if state.status == 'pending':
             state.set_status('failure')
-            desc = 'Test failed'
-            utils.github_create_status(state.get_repo(), state.head_sha,
-                                       'failure', url, desc, context='homu')
+            utils.github_create_status(
+                state.get_repo(), state.head_sha,
+                'failure', url, "Test failed", context='homu'
+            )
 
-            state.add_comment(':broken_heart: {} - [{}]({})'.format(desc,
-                                                                    builder,
-                                                                    url))
-            event = LabelEvent.TRY_FAILED if state.try_ else LabelEvent.FAILED
-            state.change_labels(event)
+            if state.try_:
+                state.add_comment(comments.TryBuildFailed(
+                    builder_url=url,
+                    builder_name=builder,
+                ))
+                state.change_labels(LabelEvent.TRY_FAILED)
+            else:
+                state.add_comment(comments.BuildFailed(
+                    builder_url=url,
+                    builder_name=builder,
+                ))
+                state.change_labels(LabelEvent.FAILED)
 
     g.queue_handler()
 

--- a/homu/server.py
+++ b/homu/server.py
@@ -505,7 +505,7 @@ def github():
             for name, value in repo_cfg['status'].items():
                 if 'context' in value and value['context'] == info['context']:
                     status_name = name
-        if status_name is "":
+        if status_name == "":
             return 'OK'
 
         if info['state'] == 'pending':


### PR DESCRIPTION
This PR changes homu to output a JSON version of each build-related comment (build started, build failed, build completed) so bots can easily parse it. This is useful for example to automatically detect when a try build is completed, or to capture its hash automatically.

The JSON output is appended to each comment inside an HTML comment, like this:

```
<!-- homu: {"type": "MessageType", ...} -->
```

For example:

```
<!-- homu: {"type":"TryBuildCompleted","merge_sha":"2b723429a9fa15e4e1098567c68b754aa6ef6bc8","builders":{"checks-travis":"https://travis-ci.com/pietroalbini/test-repo/builds/100369263"}} -->
```

cc @GuillaumeGomez