### PR TITLE
Integrate with the team repo

### DIFF
--- a/cfg.sample.toml
+++ b/cfg.sample.toml
@@ -60,6 +60,11 @@ sync_on_start = true
 owner = ""
 name = ""
 
+# If this repo should be integrated with the permissions defined in
+# https://github.com/rust-lang/team uncomment the following line.
+# Note that the other ACLs will *also* apply.
+#rust_team = true
+
 # Who can approve PRs (r+ rights)? You can put GitHub usernames here.
 reviewers = []
 # Alternatively, set this  allow any github collaborator;

--- a/homu/auth.py
+++ b/homu/auth.py
@@ -1,0 +1,48 @@
+def verify_level(username, repo_cfg, state, toml_keys):
+    authorized = False
+    if repo_cfg.get('auth_collaborators', False):
+        authorized = state.get_repo().is_collaborator(username)
+    if not authorized:
+        authorized = username.lower() == state.delegate.lower()
+    for toml_key in toml_keys:
+        if not authorized:
+            authorized = username in repo_cfg.get(toml_key, [])
+    return authorized
+
+
+def verify(username, repo_cfg, state, auth, realtime, my_username):
+    # The import is inside the function to prevent circular imports: main.py
+    # requires auth.py and auth.py requires main.py
+    from .main import AuthState
+
+    # In some cases (e.g. non-fully-qualified r+) we recursively talk to
+    # ourself via a hidden markdown comment in the message. This is so that
+    # when re-synchronizing after shutdown we can parse these comments and
+    # still know the SHA for the approval.
+    #
+    # So comments from self should always be allowed
+    if username == my_username:
+        return True
+
+    authorized = False
+    if auth == AuthState.REVIEWER:
+        authorized = verify_level(username, repo_cfg, state, ['reviewers'])
+    elif auth == AuthState.TRY:
+        authorized = verify_level(
+            username, repo_cfg, state, ['reviewers', 'try_users'],
+        )
+
+    if authorized:
+        return True
+    else:
+        if realtime:
+            reply = '@{}: :key: Insufficient privileges: '.format(username)
+            if auth == AuthState.REVIEWER:
+                if repo_cfg.get('auth_collaborators', False):
+                    reply += 'Collaborator required'
+                else:
+                    reply += 'Not in reviewers'
+            elif auth == AuthState.TRY:
+                reply += 'not in try users'
+            state.add_comment(reply)
+        return False

--- a/homu/auth.py
+++ b/homu/auth.py
@@ -1,7 +1,28 @@
-def verify_level(username, repo_cfg, state, toml_keys):
+import requests
+
+
+RUST_TEAM_BASE = "https://team-api.infra.rust-lang.org/v1/"
+
+
+def fetch_rust_team(repo_label, level):
+    repo = repo_label.replace('-', '_')
+    url = RUST_TEAM_BASE + "permissions/bors." + repo + "." + level + ".json"
+    try:
+        resp = requests.get(url)
+        resp.raise_for_status()
+        return resp.json()["github_users"]
+    except requests.exceptions.RequestException as e:
+        print("error while fetching " + url + ": " + str(e))
+        return []
+
+
+def verify_level(username, repo_label, repo_cfg, state, toml_keys,
+                 rust_team_level):
     authorized = False
     if repo_cfg.get('auth_collaborators', False):
         authorized = state.get_repo().is_collaborator(username)
+    if repo_cfg.get('rust_team', False):
+        authorized = username in fetch_rust_team(repo_label, rust_team_level)
     if not authorized:
         authorized = username.lower() == state.delegate.lower()
     for toml_key in toml_keys:
@@ -10,7 +31,7 @@ def verify_level(username, repo_cfg, state, toml_keys):
     return authorized
 
 
-def verify(username, repo_cfg, state, auth, realtime, my_username):
+def verify(username, repo_label, repo_cfg, state, auth, realtime, my_username):
     # The import is inside the function to prevent circular imports: main.py
     # requires auth.py and auth.py requires main.py
     from .main import AuthState
@@ -26,10 +47,13 @@ def verify(username, repo_cfg, state, auth, realtime, my_username):
 
     authorized = False
     if auth == AuthState.REVIEWER:
-        authorized = verify_level(username, repo_cfg, state, ['reviewers'])
+        authorized = verify_level(
+            username, repo_label, repo_cfg, state, ['reviewers'], 'review',
+        )
     elif auth == AuthState.TRY:
         authorized = verify_level(
-            username, repo_cfg, state, ['reviewers', 'try_users'],
+            username, repo_label, repo_cfg, state, ['reviewers', 'try_users'],
+            'try',
         )
 
     if authorized:

--- a/homu/main.py
+++ b/homu/main.py
@@ -413,14 +413,15 @@ PORTAL_TURRET_DIALOG = ["Target acquired", "Activated", "There you are"]
 PORTAL_TURRET_IMAGE = "https://cloud.githubusercontent.com/assets/1617736/22222924/c07b2a1c-e16d-11e6-91b3-ac659550585c.png"  # noqa
 
 
-def parse_commands(body, username, repo_cfg, state, my_username, db, states,
-                   *, realtime=False, sha=''):
+def parse_commands(body, username, repo_label, repo_cfg, state, my_username,
+                   db, states, *, realtime=False, sha=''):
     global global_cfg
     state_changed = False
 
     _reviewer_auth_verified = functools.partial(
         verify_auth,
         username,
+        repo_label,
         repo_cfg,
         state,
         AuthState.REVIEWER,
@@ -430,6 +431,7 @@ def parse_commands(body, username, repo_cfg, state, my_username, db, states,
     _try_auth_verified = functools.partial(
         verify_auth,
         username,
+        repo_label,
         repo_cfg,
         state,
         AuthState.TRY,
@@ -551,8 +553,8 @@ def parse_commands(body, username, repo_cfg, state, my_username, db, states,
                     state.change_labels(LabelEvent.APPROVED)
 
         elif word == 'r-':
-            if not verify_auth(username, repo_cfg, state, AuthState.REVIEWER,
-                               realtime, my_username):
+            if not verify_auth(username, repo_label, repo_cfg, state,
+                               AuthState.REVIEWER, realtime, my_username):
                 continue
 
             state.approved_by = ''
@@ -561,8 +563,8 @@ def parse_commands(body, username, repo_cfg, state, my_username, db, states,
                 state.change_labels(LabelEvent.REJECTED)
 
         elif word.startswith('p='):
-            if not verify_auth(username, repo_cfg, state, AuthState.TRY,
-                               realtime, my_username):
+            if not verify_auth(username, repo_label, repo_cfg, state,
+                               AuthState.TRY, realtime, my_username):
                 continue
             try:
                 pvalue = int(word[len('p='):])
@@ -580,8 +582,8 @@ def parse_commands(body, username, repo_cfg, state, my_username, db, states,
             state.save()
 
         elif word.startswith('delegate='):
-            if not verify_auth(username, repo_cfg, state, AuthState.REVIEWER,
-                               realtime, my_username):
+            if not verify_auth(username, repo_label, repo_cfg, state,
+                               AuthState.REVIEWER, realtime, my_username):
                 continue
 
             state.delegate = word[len('delegate='):]
@@ -1483,6 +1485,7 @@ def synchronize(repo_label, repo_cfg, logger, gh, states, repos, db, mergeable_q
                 parse_commands(
                     comment.body,
                     comment.user.login,
+                    repo_label,
                     repo_cfg,
                     state,
                     my_username,
@@ -1495,6 +1498,7 @@ def synchronize(repo_label, repo_cfg, logger, gh, states, repos, db, mergeable_q
             parse_commands(
                 comment.body,
                 comment.user.login,
+                repo_label,
                 repo_cfg,
                 state,
                 my_username,

--- a/homu/server.py
+++ b/homu/server.py
@@ -343,6 +343,7 @@ def github():
                 if parse_commands(
                     body,
                     username,
+                    repo_label,
                     repo_cfg,
                     state,
                     g.my_username,
@@ -389,6 +390,7 @@ def github():
                     found = parse_commands(
                         c.body,
                         c.user.login,
+                        repo_label,
                         repo_cfg,
                         state,
                         g.my_username,
@@ -507,6 +509,7 @@ def github():
             if parse_commands(
                 body,
                 username,
+                repo_label,
                 repo_cfg,
                 state,
                 g.my_username,


### PR DESCRIPTION
This PR moves the auth code to its own file (a small step torwards breaking up the huge `main.py`) and adds an optional key to integrate with the team repo.

r? @Mark-Simulacrum or @kennytm or @alexcrichton 