### PR TITLE
When sorting, lump rollup=never and rollup=maybe

### DIFF
--- a/homu/main.py
+++ b/homu/main.py
@@ -180,7 +180,9 @@ class PullReqState:
             STATUS_TO_PRIORITY.get(self.get_status(), -1),
             1 if self.mergeable is False else 0,
             0 if self.approved_by else 1,
-            self.rollup,
+            # Sort rollup=always to the bottom of the queue, but treat all
+            # other rollup statuses as equivalent
+            1 if WORDS_TO_ROLLUP['rollup=always'] == self.rollup else 0,
             -self.priority,
             self.num,
         ]


### PR DESCRIPTION
When determining the sort order for merge requests, ~~always rank based on priority before ranking based on rollup status~~ always sort `rollup=always` to the bottom of the list, and ignore any other rollup status. 

~~Previously, a PR with `priority=0`, `rollup=never` would be in the queue
above a PR with `priority=1`, `rollup=maybe`. This commit makes it so
that PRs with `priority=1` will always rank PRs with `priority=0`,
regardless of rollup status (even if `rollup=always`).~~

Previously, a PR with `priority=0`, `rollup=never` would be in the queue above a PR with `priority=1`, `rollup=maybe`. This commit makes it so that PRs with `rollup=never` is **not** given higher weight than `rollup-maybe`, so the `priority=1` pull will rank higher.

Fixes #27