### PR TITLE
Fix build result pages for pending jobs

### DIFF
--- a/homu/html/build_res.html
+++ b/homu/html/build_res.html
@@ -47,7 +47,13 @@
                 <tr>
                     <td class="hide">{{loop.index}}</td>
                     <td>{{builder.name}}</td>
-                    <td class="{{builder.result}}"><a href="{{builder.url}}">{{builder.result}}</a></td>
+                    <td class="{{builder.result}}">
+                        {%- if builder.url -%}
+                            <a href="{{builder.url}}">{{builder.result}}</a>
+                        {%- else -%}
+                            {{ builder.result }}
+                        {%- endif -%}
+                    </td>
                 </tr>
                 {% endfor %}
             </tbody>

--- a/homu/server.py
+++ b/homu/server.py
@@ -82,7 +82,7 @@ def result(repo_label, pull):
     states = [state for state in g.states[repo_label].values()
               if state.num == pull]
     if len(states) == 0:
-        abort(204, 'No build results for pull request {}'.format(pull))
+        abort(404, 'No build results for pull request {}'.format(pull))
 
     state = states[0]
     builders = []
@@ -94,15 +94,15 @@ def result(repo_label, pull):
         if data['res'] is not None:
             result = "success" if data['res'] else "failed"
 
-        if not data['url']:
-            # This happens to old try builds
-            abort(204, 'No build results for pull request {}'.format(pull))
-
-        builders.append({
-            'url': data['url'],
+        builder_details = {
             'result': result,
             'name': builder,
-        })
+        }
+
+        if data['url']:
+            builder_details['url'] = data['url']
+
+        builders.append(builder_details)
 
     return g.tpls['build_res'].render(repo_label=repo_label, repo_url=repo_url,
                                       builders=builders, pull=pull)


### PR DESCRIPTION
We have a link on the queue page for success, pending, and failed jobs. Links to pending jobs seem to never work. This seems to be because we return HTTP status code 204, which means that no content is available.

Update the result page to always attempt to show a table instead of returning a 204 when we know about the pull request, even if we have no build statuses.

Update the result page to return a 404 instead of a 204 when we have no information on the pull request. This gives some information to the end user, instead of appearing to do nothing.