### PR TITLE
Always try when receiving a `try` command

### DIFF
--- a/homu/main.py
+++ b/homu/main.py
@@ -672,6 +672,10 @@ def parse_commands(body, username, repo_label, repo_cfg, state, my_username,
 
             state.save()
             if realtime and state.try_:
+                # If we've tried before, the status will be 'success', and this
+                # new try will not be picked up. Set the status back to ''
+                # so the try will be run again.
+                state.set_status('')
                 # `try-` just resets the `try` bit and doesn't correspond to
                 # any meaningful labeling events.
                 state.change_labels(LabelEvent.TRY)


### PR DESCRIPTION
When receiving a `try` command, always try the current commit,
regardless of whether this pull request has been tried previously.

Before this commit, we need to issue

    @bors retry try

to kick off a try build after one has already run.

Fixes #34