### PR TITLE
Add support for try_name in checks

### DIFF
--- a/cfg.sample.toml
+++ b/cfg.sample.toml
@@ -158,6 +158,10 @@ name = "Travis CI - Branch"
 #
 # String name of the Checks run.
 #name = ""
+#
+# String name of the Checks run used for try runs.
+# If the field is omitted the same name as the auto build will be used.
+#try_name = ""
 
 # Use buildbot for running tests
 #[repo.NAME.buildbot]

--- a/homu/main.py
+++ b/homu/main.py
@@ -1230,7 +1230,11 @@ def start_build(state, repo_cfgs, buildbot_slots, logger, db, git_cfg):
         if found_travis_context and len(builders) == 1:
             can_try_travis_exemption = True
     if 'checks' in repo_cfg:
-        builders += ['checks-' + key for key, value in repo_cfg['checks'].items() if 'name' in value]  # noqa
+        builders += [
+            'checks-' + key
+            for key, value in repo_cfg['checks'].items()
+            if 'name' in value or (state.try_ and 'try_name' in value)
+        ]
         only_status_builders = False
 
     if len(builders) == 0:

--- a/homu/server.py
+++ b/homu/server.py
@@ -604,7 +604,10 @@ def github():
         checks_name = None
         if 'checks' in repo_cfg:
             for name, value in repo_cfg['checks'].items():
-                if 'name' in value and value['name'] == current_run_name:
+                if state.try_ and 'try_name' in value:
+                    if value['try_name'] == current_run_name:
+                        checks_name = name
+                elif 'name' in value and value['name'] == current_run_name:
                     checks_name = name
         if checks_name is None:
             return 'OK'


### PR DESCRIPTION
In the Azure Pipelines configuration for rustc we have two different pipelines for auto builds and try builds, thus two different check names. This adds support for specifying a different check name for try builds.

r? @alexcrichton 
fixes https://github.com/rust-lang/homu/issues/37