### PR TITLE
Fix repository type error

### DIFF
--- a/homu/main.py
+++ b/homu/main.py
@@ -77,7 +77,7 @@ def db_query(db, *args):
 
 class Repository:
     treeclosed = -1
-    treecloesd_src = None
+    treeclosed_src = None
     gh = None
     label = None
     db = None
@@ -94,7 +94,7 @@ class Repository:
         row = db.fetchone()
         if row:
             self.treeclosed = row[0]
-            self.treecloesd_src = row[1]
+            self.treeclosed_src = row[1]
         else:
             self.treeclosed = -1
             self.treeclosed_src = None

--- a/homu/server.py
+++ b/homu/server.py
@@ -63,7 +63,7 @@ def get_repo(repo_label, repo_cfg):
     repo = g.repos[repo_label].gh
     if not repo:
         repo = g.gh.repository(repo_cfg['owner'], repo_cfg['name'])
-        g.repos[repo_label] = repo
+        g.repos[repo_label].gh = repo
         assert repo.owner.login == repo_cfg['owner']
         assert repo.name == repo_cfg['name']
     return repo


### PR DESCRIPTION
Fix a type error where we (potentially) mistakenly assign a
`github3.repos.repo.Repository` object to a place where we expect a
`Repository` (as defined in main.py).

It appears this was intended in 2067c37d but missed.

Also fix a typo in a variable name that doesn't seem to have caused
problems yet, but let's be safe.