### PR TITLE
try builds: include a copyable version of the full commit SHA in comment

### DIFF
--- a/homu/comments.py
+++ b/homu/comments.py
@@ -113,8 +113,8 @@ class TryBuildCompleted(Comment):
         urls = ", ".join(
             "[%s](%s)" % kv for kv in sorted(self.builders.items())
         )
-        return ":sunny: Try build successful - %s\nBuild commit: %s" % (
-            urls, self.merge_sha,
+        return ":sunny: Try build successful - %s\nBuild commit: %s (`%s`)" % (
+            urls, self.merge_sha, self.merge_sha,
         )
 
 


### PR DESCRIPTION
I regularly trigger try builds to then do a perf run. Perfbot needs the full 40-char SHA1 of the commit. To get that from what bors gives me on a successful try build (like [this comment](https://github.com/rust-lang/rust/pull/62264#issuecomment-507678742)), I need to copy the URL of that link and then remove the junk before the commit.

With this, my hope is I will get a 40-char SHA1 that I can just double-click, Ctrl-C, done. :)
I don't know how to test this change, though.