### PR TITLE
Add test to ensure @bors only responds to itself

### DIFF
--- a/homu/tests/test_parse_issue_comment.py
+++ b/homu/tests/test_parse_issue_comment.py
@@ -497,6 +497,20 @@ def test_multiple_hooks():
     assert thirdhook_commands[0].hook_extra is None
 
 
+def test_similar_name():
+    """
+    Test that a username that starts with 'bors' doesn't trigger.
+    """
+
+    author = "jack"
+    body = """
+    @bors-servo r+
+    """
+    commands = parse_issue_comment(author, body, commit, "bors")
+
+    assert len(commands) == 0
+
+
 def test_parse_up_to_first_unknown_word():
     """
     Test that when parsing, once we arrive at an unknown word, we stop parsing


### PR DESCRIPTION
Test that we only respond when a command is issued to `@bors`, and not to `@bors-servo` or any other `@bors{something}` bot.

This came up because a comment on `rust-lang/rust` referenced `@bors-servo` instead of `@bors` and was still approved successfully. (https://github.com/rust-lang/rust/pull/62613#issuecomment-510923557) The command-parsing changes apparently already fixed this, but add a test to prevent regressions.