### PR TITLE
Include extra information in metadata comments

### DIFF
--- a/homu/comments.py
+++ b/homu/comments.py
@@ -119,7 +119,7 @@ class TryBuildCompleted(Comment):
 
 
 class BuildFailed(Comment):
-    params = ["builder_url", "builder_name"]
+    params = ["builder_url", "builder_name", "merge_sha"]
 
     def render(self):
         return ":broken_heart: Test failed - [%s](%s)" % (
@@ -128,7 +128,7 @@ class BuildFailed(Comment):
 
 
 class TryBuildFailed(Comment):
-    params = ["builder_url", "builder_name"]
+    params = ["builder_url", "builder_name", "merge_sha"]
 
     def render(self):
         return ":broken_heart: Test failed - [%s](%s)" % (
@@ -137,7 +137,7 @@ class TryBuildFailed(Comment):
 
 
 class TimedOut(Comment):
-    params = []
+    params = ["merge_sha"]
 
     def render(self):
         return ":boom: Test timed out"

--- a/homu/comments.py
+++ b/homu/comments.py
@@ -72,7 +72,7 @@ class Delegated(Comment):
 
 
 class BuildStarted(Comment):
-    params = ["head_sha", "merge_sha"]
+    params = ["head_sha", "merge_sha", "started_at"]
 
     def render(self):
         return ":hourglass: Testing commit %s with merge %s..." % (
@@ -81,7 +81,7 @@ class BuildStarted(Comment):
 
 
 class TryBuildStarted(Comment):
-    params = ["head_sha", "merge_sha"]
+    params = ["head_sha", "merge_sha", "started_at"]
 
     def render(self):
         return ":hourglass: Trying commit %s with merge %s..." % (
@@ -90,7 +90,7 @@ class TryBuildStarted(Comment):
 
 
 class BuildCompleted(Comment):
-    params = ["approved_by", "base_ref", "builders", "merge_sha"]
+    params = ["approved_by", "base_ref", "builders", "merge_sha", "ended_at"]
 
     def render(self):
         urls = ", ".join(
@@ -107,7 +107,7 @@ class BuildCompleted(Comment):
 
 
 class TryBuildCompleted(Comment):
-    params = ["builders", "merge_sha"]
+    params = ["builders", "merge_sha", "ended_at"]
 
     def render(self):
         urls = ", ".join(
@@ -119,7 +119,7 @@ class TryBuildCompleted(Comment):
 
 
 class BuildFailed(Comment):
-    params = ["builder_url", "builder_name", "merge_sha"]
+    params = ["builder_url", "builder_name", "merge_sha", "ended_at"]
 
     def render(self):
         return ":broken_heart: Test failed - [%s](%s)" % (
@@ -128,7 +128,7 @@ class BuildFailed(Comment):
 
 
 class TryBuildFailed(Comment):
-    params = ["builder_url", "builder_name", "merge_sha"]
+    params = ["builder_url", "builder_name", "merge_sha", "ended_at"]
 
     def render(self):
         return ":broken_heart: Test failed - [%s](%s)" % (
@@ -137,7 +137,7 @@ class TryBuildFailed(Comment):
 
 
 class TimedOut(Comment):
-    params = ["merge_sha"]
+    params = ["merge_sha", "ended_at"]
 
     def render(self):
         return ":boom: Test timed out"

--- a/homu/main.py
+++ b/homu/main.py
@@ -8,7 +8,10 @@ from . import comments
 from . import utils
 from .parse_issue_comment import parse_issue_comment
 from .auth import verify as verify_auth
-from .utils import lazy_debug
+from .utils import (
+    iso_utc_now,
+    lazy_debug,
+)
 import logging
 from threading import Thread, Lock, Timer
 import time
@@ -393,7 +396,10 @@ class PullReqState:
             '',
             'Test timed out',
             context='homu')
-        self.add_comment(comments.TimedOut(merge_sha=merge_sha))
+        self.add_comment(comments.TimedOut(
+            merge_sha=merge_sha,
+            ended_at=iso_utc_now(),
+        ))
         self.change_labels(LabelEvent.TIMED_OUT)
 
     def record_retry_log(self, src, body):
@@ -1302,11 +1308,13 @@ def start_build(state, repo_cfgs, buildbot_slots, logger, db, git_cfg):
         state.add_comment(comments.TryBuildStarted(
             head_sha=state.head_sha,
             merge_sha=state.merge_sha,
+            started_at=iso_utc_now(),
         ))
     else:
         state.add_comment(comments.BuildStarted(
             head_sha=state.head_sha,
             merge_sha=state.merge_sha,
+            started_at=iso_utc_now(),
         ))
 
     return True

--- a/homu/main.py
+++ b/homu/main.py
@@ -381,6 +381,7 @@ class PullReqState:
     def timed_out(self):
         print('* Test timed out: {}'.format(self))
 
+        merge_sha = self.merge_sha
         self.merge_sha = ''
         self.save()
         self.set_status('failure')
@@ -392,7 +393,7 @@ class PullReqState:
             '',
             'Test timed out',
             context='homu')
-        self.add_comment(comments.TimedOut())
+        self.add_comment(comments.TimedOut(merge_sha=merge_sha))
         self.change_labels(LabelEvent.TIMED_OUT)
 
     def record_retry_log(self, src, body):

--- a/homu/server.py
+++ b/homu/server.py
@@ -11,7 +11,10 @@ from .main import (
 )
 from . import comments
 from . import utils
-from .utils import lazy_debug
+from .utils import (
+    iso_utc_now,
+    lazy_debug,
+)
 import github3
 import jinja2
 import requests
@@ -659,6 +662,7 @@ def report_build_res(succ, sha, url, builder, state, logger, repo_cfg):
                     base_ref=state.base_ref,
                     builders={k: v["url"] for k, v in state.build_res.items()},
                     merge_sha=state.merge_sha,
+                    ended_at=iso_utc_now(),
                 ))
                 state.change_labels(LabelEvent.SUCCEED)
                 try:
@@ -690,6 +694,7 @@ def report_build_res(succ, sha, url, builder, state, logger, repo_cfg):
                 state.add_comment(comments.TryBuildCompleted(
                     builders={k: v["url"] for k, v in state.build_res.items()},
                     merge_sha=state.merge_sha,
+                    ended_at=iso_utc_now(),
                 ))
                 state.change_labels(LabelEvent.TRY_SUCCEED)
 
@@ -706,6 +711,7 @@ def report_build_res(succ, sha, url, builder, state, logger, repo_cfg):
                     builder_url=url,
                     builder_name=builder,
                     merge_sha=sha,
+                    ended_at=iso_utc_now(),
                 ))
                 state.change_labels(LabelEvent.TRY_FAILED)
             else:
@@ -713,6 +719,7 @@ def report_build_res(succ, sha, url, builder, state, logger, repo_cfg):
                     builder_url=url,
                     builder_name=builder,
                     merge_sha=sha,
+                    ended_at=iso_utc_now(),
                 ))
                 state.change_labels(LabelEvent.FAILED)
 

--- a/homu/utils.py
+++ b/homu/utils.py
@@ -6,6 +6,14 @@ import sys
 import traceback
 import requests
 import time
+import datetime
+
+
+def iso_utc_now():
+    return datetime.datetime \
+            .utcnow() \
+            .replace(tzinfo=datetime.timezone.utc, microsecond=0) \
+            .isoformat()
 
 
 def github_set_ref(repo, ref, sha, *, force=False, auto_create=True, retry=1):


### PR DESCRIPTION
Include the `merge_sha` in BuildFailed, TryBuildFailed, and TimedOut metadata comments.

This helps with synchronizing historical data, and will help in the future correlating which build a failure is associated with.

Also include `started_at` or `ended_at` in all build-related comments.

Timing information could be gleaned from comment times, but make it explicit in the metadata. This means we can get the true times, even if GitHub has delays.

This also gives us the opportunity to have more control in the future. For example, the [check_run event][check_run] includes `started_at` and `completed_at` information that is independent from when GitHub sent us the webhook.

[check_run]: https://developer.github.com/v3/activity/events/types/#checkrunevent-api-payload

There are no visible changes to any of the comments.

Example success:

```
<!-- homu: {
  "type":"TryBuildStarted",
  "head_sha":"3bad62d39be0c9431e2c7d559faf7853080e6754",
  "merge_sha":"0ca0d33271785934fe6a9b2dacdd301ea9efd967",
  "started_at":"2019-08-16T17:10:46+00:00"} -->

<!-- homu: {
  "type":"TryBuildCompleted",
  "builders":{"checks-travis":"https://travis-ci.com/bryanburgers/homu-test-2/builds/123541077"},
  "merge_sha":"0ca0d33271785934fe6a9b2dacdd301ea9efd967",
  "ended_at":"2019-08-16T17:11:49+00:00"} -->
```

Example timeout:

```
<!-- homu: {
  "type":"TryBuildStarted",
  "head_sha":"4d92d990ed2c511596d4f7bd064fbd610b30bcb1",
  "merge_sha":"afbca6e5862f53900d222e636e17ccf26b34f8e1",
  "started_at":"2019-08-16T17:06:39+00:00"} -->

<!-- homu: {
  "type":"TimedOut",
  "merge_sha":"afbca6e5862f53900d222e636e17ccf26b34f8e1",
  "ended_at":"2019-08-16T17:06:59+00:00"} -->
```

Example failure:

```
<!-- homu: {
  "type":"TryBuildStarted",
  "head_sha":"4d92d990ed2c511596d4f7bd064fbd610b30bcb1",
  "merge_sha":"896efebc02ec62855a3b93ed1497ecc3dd311c56",
  "started_at":"2019-08-16T17:07:48+00:00"} -->

<!-- homu: {
  "type":"TryBuildFailed",
  "builder_url":"https://travis-ci.com/bryanburgers/homu-test-2/builds/123540732",
  "builder_name":"checks-travis",
  "merge_sha":"896efebc02ec62855a3b93ed1497ecc3dd311c56",
  "ended_at":"2019-08-16T17:08:51+00:00"} -->
```