### PR TITLE
Shift success rows in queue to bottom

### DIFF
--- a/homu/main.py
+++ b/homu/main.py
@@ -27,12 +27,12 @@ import random
 import weakref
 
 STATUS_TO_PRIORITY = {
-    'success': 0,
     'pending': 1,
     'approved': 2,
     '': 3,
     'error': 4,
     'failure': 5,
+    'success': 6,
 }
 
 INTERRUPTED_BY_HOMU_FMT = 'Interrupted by Homu ({})'


### PR DESCRIPTION
Generally these are try builds which have concluded; ideally we wouldn't show
them at all (there's really no reason for them to be in the queue) but that's a
harder change. On the rust-lang/rust queue these typically take up the first 1.5
pages of queue -- which is wasteful, as there's not really interesting
information to be gleaned from them.

This moves that list to the bottom of the page.

r? @pietroalbini 