### PR TITLE
Link to Git guide in rustc-dev-guide on merge conflicts

### DIFF
--- a/homu/main.py
+++ b/homu/main.py
@@ -1490,8 +1490,8 @@ def fetch_mergeability(mergeable_que):
                     _blame = ' (presumably {})'.format(issue_or_commit)
                 state.add_comment(
                     ':umbrella: The latest upstream changes{} made this '
-                    'pull request unmergeable. Please resolve the merge '
-                    'conflicts.\n\n'
+                    'pull request unmergeable. Please [resolve the merge conflicts]'  # noqa
+                    '(https://rustc-dev-guide.rust-lang.org/git.html#conflicts).\n\n'  # noqa
                     '*Note that reviewers usually do not review pull requests '
                     'until merge conflicts are resolved!* Once you resolve '
                     'the conflicts, you should change the labels applied by '


### PR DESCRIPTION
Dependent on rust-lang/rustc-dev-guide#890 being merged, so this is draft. 

That PR was merged, so this is ready!