### PR TITLE
Add support for moving homu to bors.rust-lang.org

### DIFF
--- a/cfg.sample.toml
+++ b/cfg.sample.toml
@@ -43,6 +43,15 @@ port = 54856
 # all open PRs.
 sync_on_start = true
 
+# The canonical URL of this homu instance. If a user reaches the instance
+# through a different path they will be redirected. If this is not present in
+# the configuration homu will still work, but no redirect will be performed.
+#canonical_url = "https://bors.example.com"
+
+# List of path prefixes to remove from the URL. This is useful if the homu
+# instance was moved from a subdirectory of a domain to the top level.
+#remove_path_prefixes = ["homu"]
+
 # Custom hooks can be added as well.
 # Homu will ping the given endpoint with POSTdata of the form:
 # {'body': 'comment body', 'extra_data': 'extra data', 'pull': pull req number}

--- a/cfg.sample.toml
+++ b/cfg.sample.toml
@@ -52,6 +52,10 @@ sync_on_start = true
 # instance was moved from a subdirectory of a domain to the top level.
 #remove_path_prefixes = ["homu"]
 
+# Message to display on top of the web interface. It's possible to use
+# arbitrary HTML tags in the message.
+#announcement = "Homu will be offline tomorrow for maintenance."
+
 # Custom hooks can be added as well.
 # Homu will ping the given endpoint with POSTdata of the form:
 # {'body': 'comment body', 'extra_data': 'extra data', 'pull': pull req number}

--- a/homu/html/index.html
+++ b/homu/html/index.html
@@ -12,75 +12,94 @@
             h4 { font-size: 14px; }
             p, ul { font-size: 15px; line-height: 150%; }
             code { background-color: #efefef; }
-            body { max-width: 60em; margin-left: auto; margin-right: auto; }
+            div.wrapper { max-width: 60em; margin-left: auto; margin-right: auto; }
             .repos { font-size: 18px; line-height: 180%; }
+
+            #announcement {
+                margin: -8px -8px 1em -8px;
+                padding: 0.5em 1em;
+                text-align: center;
+                background: #eee;
+                border-bottom: 1px solid #ccc;
+            }
+            #announcement a:visited {
+                color: #00f;
+            }
         </style>
     </head>
     <body>
-        <h1>Homu</h1>
+        {% if announcement != None %}
+        <div id="announcement">{{ announcement | safe }}</div>
+        {% endif %}
 
-        <h2>Repositories</h2>
+        <div class="wrapper">
 
-        <ul class="repos">
-            {% for repo in repos %}
-            <li><a href="queue/{{repo.repo_label}}">{{repo.repo_label}}</a> {% if repo.treeclosed >= 0 %} [TREE CLOSED] {% endif %}</li>
-            {% endfor %}
-        </ul>
+            <h1>Homu</h1>
 
-        <hr>
+            <h2>Repositories</h2>
 
-        <h2>Homu Cheatsheet</h2>
+            <ul class="repos">
+                {% for repo in repos %}
+                <li><a href="queue/{{repo.repo_label}}">{{repo.repo_label}}</a> {% if repo.treeclosed >= 0 %} [TREE CLOSED] {% endif %}</li>
+                {% endfor %}
+            </ul>
 
-        <h3>Commands</h3>
+            <hr>
 
-        <p>
-            Here's a quick reference for the commands Homu accepts. Commands must be posted as
-            comments on the PR they refer to. Comments may include multiple commands. Homu will
-            only listen to official reviewers that it is configured to listen to. A comment
-            must mention the GitHub account Homu is configured to use. (e.g. for the Rust project this is @bors)
-            Note that Homu will only recognize comments in <i>open</i> PRs.
-        </p>
+            <h2>Homu Cheatsheet</h2>
 
-        <ul>
-            <li><code>r+ (SHA)</code>: Accept a PR. Optionally, the SHA of the last commit in the PR can be provided as a guard against synchronization issues or malicious users. Regardless of the form used, PRs will automatically be unaccepted if the contents are changed.</li>
-            <li><code>r=NAME (SHA)</code>: Accept a PR on the behalf of NAME.</li>
-            <li><code>r-</code>: Unacccept a PR.</li>
-            <li><code>p=NUMBER</code>: Set the priority of the accepted PR (defaults to 0).</li>
-            <li><code>rollup</code>: Mark the PR as likely to merge without issue, short for <code>rollup=always</code></li>
-            <li><code>rollup-</code>: Unmark the PR as <code>rollup</code>.</li>
-            <li><code>rollup=maybe|always|iffy|never</code>: Mark the PR as "always", "maybe", "iffy", and "never" rollup-able.</li>
-            <li><code>retry</code>: Signal that the PR is not bad, and should be retried by buildbot.</li>
-            <li><code>try</code>: Request that the PR be tested by buildbot, without accepting it.</li>
-            <li><code>force</code>: Stop all the builds on the configured builders, and proceed to the next PR.</li>
-            <li><code>clean</code>: Clean up the previous build results.</li>
-            <li><code>delegate=NAME</code>: Allow NAME to issue all homu commands for this PR.</li>
-            <li><code>delegate+</code>: Delegate to the PR owner.</li>
-            <li><code>delegate-</code>: Remove the delegatee.</li>
-            <li><code>treeclosed=NUMBER</code>: Any PR below priority <code>NUMBER</code> will not test. Please consider if you <i>really</i> want to do this.</li>
-            <li><code>treeclosed-</code>: Undo a previous <code>treeclosed=NUMBER</code>.</li>
-        </ul>
+            <h3>Commands</h3>
 
-        <h4>Examples</h4>
+            <p>
+                Here's a quick reference for the commands Homu accepts. Commands must be posted as
+                comments on the PR they refer to. Comments may include multiple commands. Homu will
+                only listen to official reviewers that it is configured to listen to. A comment
+                must mention the GitHub account Homu is configured to use. (e.g. for the Rust project this is @bors)
+                Note that Homu will only recognize comments in <i>open</i> PRs.
+            </p>
 
-        <ul>
-            <li><code>@bors r+ p=1</code></li>
-            <li><code>@bors r+ 123456</code></li>
-            <li><code>@bors r=barosl rollup</code></li>
-            <li><code>@bors retry</code></li>
-            <li><code>@bors try @rust-timer queue</code>: Short-hand for compile-perf benchmarking of PRs.</li>
-        </ul>
+            <ul>
+                <li><code>r+ (SHA)</code>: Accept a PR. Optionally, the SHA of the last commit in the PR can be provided as a guard against synchronization issues or malicious users. Regardless of the form used, PRs will automatically be unaccepted if the contents are changed.</li>
+                <li><code>r=NAME (SHA)</code>: Accept a PR on the behalf of NAME.</li>
+                <li><code>r-</code>: Unacccept a PR.</li>
+                <li><code>p=NUMBER</code>: Set the priority of the accepted PR (defaults to 0).</li>
+                <li><code>rollup</code>: Mark the PR as likely to merge without issue, short for <code>rollup=always</code></li>
+                <li><code>rollup-</code>: Unmark the PR as <code>rollup</code>.</li>
+                <li><code>rollup=maybe|always|iffy|never</code>: Mark the PR as "always", "maybe", "iffy", and "never" rollup-able.</li>
+                <li><code>retry</code>: Signal that the PR is not bad, and should be retried by buildbot.</li>
+                <li><code>try</code>: Request that the PR be tested by buildbot, without accepting it.</li>
+                <li><code>force</code>: Stop all the builds on the configured builders, and proceed to the next PR.</li>
+                <li><code>clean</code>: Clean up the previous build results.</li>
+                <li><code>delegate=NAME</code>: Allow NAME to issue all homu commands for this PR.</li>
+                <li><code>delegate+</code>: Delegate to the PR owner.</li>
+                <li><code>delegate-</code>: Remove the delegatee.</li>
+                <li><code>treeclosed=NUMBER</code>: Any PR below priority <code>NUMBER</code> will not test. Please consider if you <i>really</i> want to do this.</li>
+                <li><code>treeclosed-</code>: Undo a previous <code>treeclosed=NUMBER</code>.</li>
+            </ul>
 
-        <h3>Customizing the Queue's Contents</h3>
+            <h4>Examples</h4>
 
-        <p>
-            Homu provides a few simple ways to customize the queue's contents to fit your needs:
-        </p>
+            <ul>
+                <li><code>@bors r+ p=1</code></li>
+                <li><code>@bors r+ 123456</code></li>
+                <li><code>@bors r=barosl rollup</code></li>
+                <li><code>@bors retry</code></li>
+                <li><code>@bors try @rust-timer queue</code>: Short-hand for compile-perf benchmarking of PRs.</li>
+            </ul>
 
-        <ul>
-            <li><code>queue/rust+cargo</code> will combine the queues of the <code>rust</code> and <code>cargo</code> repos (for example).</li>
-            <li><a href="queue/all">queue/all</a> will combine the queues of all registered repos.</li>
-            <li>Rows can be sorted by column by clicking on column headings.</li>
-            <li>Rows can be filtered by contents using the search box (only naive substring matching supported).</li>
-        </ul>
+            <h3>Customizing the Queue's Contents</h3>
+
+            <p>
+                Homu provides a few simple ways to customize the queue's contents to fit your needs:
+            </p>
+
+            <ul>
+                <li><code>queue/rust+cargo</code> will combine the queues of the <code>rust</code> and <code>cargo</code> repos (for example).</li>
+                <li><a href="queue/all">queue/all</a> will combine the queues of all registered repos.</li>
+                <li>Rows can be sorted by column by clicking on column headings.</li>
+                <li>Rows can be filtered by contents using the search box (only naive substring matching supported).</li>
+            </ul>
+
+        </div>
     </body>
 </html>

--- a/homu/html/queue.html
+++ b/homu/html/queue.html
@@ -109,9 +109,24 @@
             .hide { display: none; }
             th { cursor: pointer; }
             #actual-rollup { background: #c7e2ff; border: #00acf7 3px double; border-radius: 5px; width: 75%; padding: 0 1em; }
+
+            #announcement {
+                margin: -8px -8px 1em -8px;
+                padding: 0.5em 1em;
+                text-align: center;
+                background: #eee;
+                border-bottom: 1px solid #ccc;
+            }
+            #announcement a:visited {
+                color: #00f;
+            }
         </style>
     </head>
     <body>
+        {% if announcement != None %}
+        <div id="announcement">{{ announcement | safe }}</div>
+        {% endif %}
+
         <h1>Homu queue - {% if repo_url %}<a href="{{repo_url}}" target="_blank">{{repo_label}}</a>{% else %}{{repo_label}}{% endif %} {% if treeclosed %} [<a href="{{treeclosed_src}}">TREE CLOSED</a> below priority {{treeclosed}}] {% endif %}</h2>
 
         <p>

--- a/homu/server.py
+++ b/homu/server.py
@@ -980,6 +980,7 @@ def start(cfg, states, queue_handler, repo_cfgs, repos, logger,
         loader=jinja2.FileSystemLoader(pkg_resources.resource_filename(__name__, 'html')),  # noqa
         autoescape=True,
     )
+    env.globals["announcement"] = cfg["web"].get("announcement")
     tpls = {}
     tpls['index'] = env.get_template('index.html')
     tpls['queue'] = env.get_template('queue.html')


### PR DESCRIPTION
This PR implements support for moving homu to a new domain name:

* Support for redirecting to a canonical domain name is implemented in homu itself with the `web.canonical_url` and `web.remove_path_prefixes` configuration keys. I chose to implement it in homu because when we'll deploy it to ECS we won't have nginx to do redirects, and it's just easier to point both the old and new domains to the container.
* Support for showing announcements at the top of the page is added, to alert contributors of the domain name change.

| ![Screenshot_2020-10-15 Homu](https://user-images.githubusercontent.com/2299951/96122526-eb266000-0ef1-11eb-93e8-85eb9daa30b4.png) | ![Screenshot_2020-10-15 Homu queue - rust  TREE CLOSED](https://user-images.githubusercontent.com/2299951/96122530-ebbef680-0ef1-11eb-9e70-1327ea7549a7.png) |
| --- | --- |
| Index page | Queue page |

I recommend to disable whitespace-only changes in the diff, as otherwise the HTML change is really noisy.
r? @Mark-Simulacrum 
