### PR TITLE
Allow using environment variables in the configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 sudo: false
 language: python
 python:
-  - 3.4
-  - 3.5
+  - 3.8
 install:
   - pip install flake8
 script:

--- a/cfg.sample.toml
+++ b/cfg.sample.toml
@@ -1,3 +1,7 @@
+# The configuration file supports variable interpolation. In any string field,
+# ${VARIABLE_NAME} will be replaced with the value of the VARIABLE_NAME
+# environment variable.
+
 # Priority values above max_priority will be refused.
 max_priority = 9001
 


### PR DESCRIPTION
This PR allows to insert configuration values from environment variables, with the `${VARIABLE_NAME}` syntax. This will be useful when deploying homu to ECS, as we'll be able to inject secrets from parameter store through environment variables.