### PR TITLE
Gate miri on GHA only

### DIFF
--- a/cfg.production.toml
+++ b/cfg.production.toml
@@ -311,10 +311,6 @@ auto = "auto"
 secret = "${HOMU_WEBHOOK_SECRET_MIRI}"
 [repo.miri.checks.actions]
 name = "bors build finished"
-[repo.miri.checks.travis]
-name = "Travis CI - Branch"
-[repo.miri.status.appveyor]
-context = "continuous-integration/appveyor/branch"
 
 ############
 #  Crater  #


### PR DESCRIPTION
It's over a week after https://github.com/rust-lang/miri/pull/1571 merged
and we've been experimenting with GHA successfully.

Last PR gated miri on GHA at <https://github.com/rust-lang/rust-central-station/pull/939>,
but the configuration moved to this repo.

cc @RalfJung
