### PR TITLE
Add a link to the rollup procedures on the forge

### DIFF
--- a/homu/html/index.html
+++ b/homu/html/index.html
@@ -66,8 +66,8 @@
                 <li><code>rollup</code>: Mark the PR as likely to merge without issue, short for <code>rollup=always</code></li>
                 <li><code>rollup-</code>: Unmark the PR as <code>rollup</code>.</li>
                 <li><code>rollup=maybe|always|iffy|never</code>: Mark the PR as "always", "maybe", "iffy", and "never" rollup-able.</li>
-                <li><code>retry</code>: Signal that the PR is not bad, and should be retried by buildbot.</li>
-                <li><code>try</code>: Request that the PR be tested by buildbot, without accepting it.</li>
+                <li><code>retry</code>: Signal that the PR is not bad, and should be retried by bors.</li>
+                <li><code>try</code>: Request that the PR be tested by bors, without accepting it.</li>
                 <li><code>force</code>: Stop all the builds on the configured builders, and proceed to the next PR.</li>
                 <li><code>clean</code>: Clean up the previous build results.</li>
                 <li><code>delegate=NAME</code>: Allow NAME to issue all homu commands for this PR.</li>

--- a/homu/html/queue.html
+++ b/homu/html/queue.html
@@ -137,18 +137,7 @@
         <div id="actual-rollup" class="hide">
             <p>This will create a new pull request consisting of <span id="checkbox-count">0</span> PRs.</p>
             <p>A rollup is useful for shortening the queue, but jumping the queue is unfair to older PRs who have waited too long.</p>
-            <p>When creating a real rollup, try to be fair to the PRs not rolled up. You may pick one of these strategies:</p>
-            <ul>
-                <li>
-                    <p>Always include the first <span class="approved">approved</span> PR in the rollup.
-                    Then give the new pull request the highest priority (p=100);</p>
-                    <p><i>or</i></p>
-                </li>
-                <li>
-                    <p>After creating the rollup, give it a fairly high priority (p=10), then assign
-                    even higher priorties (p=20, ...) to every PRs older than the oldest rolled up PR.</p>
-                </li>
-            </ul>
+            <p>When creating a real rollup, see <a href="https://forge.rust-lang.org/release/rollups.html">this instruction</a> for reference.</p>
             <p>
                 <button type="button" id="rollup">Rollup</button>
                 —


### PR DESCRIPTION
The current rollup instruction seems outdated and it should make sense to display a link to the forge page instead.

Also, does `s/buildbot/bors/g` via 71cee47 as it's a minor change and should be fine to be included here.