### PR TITLE
Store cache locally

### DIFF
--- a/cfg.production.toml
+++ b/cfg.production.toml
@@ -10,7 +10,6 @@ app_client_secret = "${GITHUB_CLIENT_SECRET}"
 
 [git]
 local_git = true
-cache_dir = "/efs/git-cache"
 ssh_key = """
 ${HOMU_SSH_KEY}
 """


### PR DESCRIPTION
EFS is shared between the (potentially multiple) instances of bors which are
running, and in general the git lockfile can get left spuriously behind (e.g.,
if we end up aborting not-nicely). The rust repository is not that big
especially without submodules too.