### PR TITLE
Add a "create a similar rollup" link in rollup PR body

### DIFF
--- a/cfg.production.toml
+++ b/cfg.production.toml
@@ -18,6 +18,7 @@ ${HOMU_SSH_KEY}
 host = '0.0.0.0'
 port = 80
 
+base_url = "https://bors.rust-lang.org"
 canonical_url = "https://bors.rust-lang.org"
 remove_path_prefixes = ["homu"]
 

--- a/cfg.sample.toml
+++ b/cfg.sample.toml
@@ -51,6 +51,12 @@ port = 54856
 # all open PRs.
 sync_on_start = true
 
+# The base url used for links pointing to this homu instance.
+# If base_url is not present, links will use canonical_url as a fallback.
+# If neither base_url nor canonical_url are present, no links to this homu
+# instance will be generated.
+#base_url = "https://bors.example.com"
+
 # The canonical URL of this homu instance. If a user reaches the instance
 # through a different path they will be redirected. If this is not present in
 # the configuration homu will still work, but no redirect will be performed.

--- a/homu/html/queue.html
+++ b/homu/html/queue.html
@@ -187,9 +187,14 @@
 
             <tbody>
                 {% for state in states %}
+                {% set checkbox_state =
+                    ('checked' if state.prechecked else '') if
+                        ((state.status == 'approved' or (state.status == 'pending' and not state.try_)) and state.rollup != 'never')
+                    else 'disabled'
+                %}
                 <tr class="{{state.greyed}}">
                     <td class="hide">{{loop.index}}</td>
-                    <td><input type="checkbox" data-num="{{state.num}}" {{ '' if ((state.status == 'approved' or (state.status == 'pending' and not state.try_)) and state.rollup != 'never') else 'disabled' }}></td>
+                    <td><input type="checkbox" data-num="{{state.num}}" {{checkbox_state}}></td>
                     {% if multiple %}
                     <td><a href="{{state.repo_url}}">{{state.repo_label}}</a></td>
                     {% endif %}

--- a/homu/main.py
+++ b/homu/main.py
@@ -43,8 +43,12 @@ VARIABLES_RE = re.compile(r'\${([a-zA-Z_]+)}')
 
 IGNORE_BLOCK_START = '<!-- homu-ignore:start -->'
 IGNORE_BLOCK_END = '<!-- homu-ignore:end -->'
-IGNORE_BLOCK_RE = re.compile(r'<!--\s*homu-ignore:start\s*-->.*<!--\s*homu-ignore:end\s*-->',
-                    flags=re.MULTILINE|re.DOTALL|re.IGNORECASE)
+IGNORE_BLOCK_RE = re.compile(
+                    r'<!--\s*homu-ignore:start\s*-->'
+                    r'.*'
+                    r'<!--\s*homu-ignore:end\s*-->',
+                    flags=re.MULTILINE | re.DOTALL | re.IGNORECASE
+                )
 
 global_cfg = {}
 
@@ -53,6 +57,7 @@ global_cfg = {}
 # Note: Don't replace non-mentions like "email@gmail.com".
 def suppress_pings(text):
     return re.sub(r'\B(@\S+)', r'`\g<1>`', text)  # noqa
+
 
 # Replace any text between IGNORE_BLOCK_START and IGNORE_BLOCK_END
 # HTML comments with an empty string in merge commits

--- a/homu/main.py
+++ b/homu/main.py
@@ -41,6 +41,11 @@ DEFAULT_TEST_TIMEOUT = 3600 * 10
 
 VARIABLES_RE = re.compile(r'\${([a-zA-Z_]+)}')
 
+IGNORE_BLOCK_START = '<!-- homu-ignore:start -->'
+IGNORE_BLOCK_END = '<!-- homu-ignore:end -->'
+IGNORE_BLOCK_RE = re.compile(r'<!--\s*homu-ignore:start\s*-->.*<!--\s*homu-ignore:end\s*-->',
+                    flags=re.MULTILINE|re.DOTALL|re.IGNORECASE)
+
 global_cfg = {}
 
 
@@ -48,6 +53,11 @@ global_cfg = {}
 # Note: Don't replace non-mentions like "email@gmail.com".
 def suppress_pings(text):
     return re.sub(r'\B(@\S+)', r'`\g<1>`', text)  # noqa
+
+# Replace any text between IGNORE_BLOCK_START and IGNORE_BLOCK_END
+# HTML comments with an empty string in merge commits
+def suppress_ignore_block(text):
+    return IGNORE_BLOCK_RE.sub('', text)
 
 
 @contextmanager
@@ -356,6 +366,7 @@ class PullReqState:
 
         self.title = issue.title
         self.body = suppress_pings(issue.body)
+        self.body = suppress_ignore_block(self.body)
 
     def fake_merge(self, repo_cfg):
         if not repo_cfg.get('linear', False):
@@ -1554,6 +1565,7 @@ def synchronize(repo_label, repo_cfg, logger, gh, states, repos, db, mergeable_q
         state = PullReqState(pull.number, pull.head.sha, status, db, repo_label, mergeable_que, gh, repo_cfg['owner'], repo_cfg['name'], repo_cfg.get('labels', {}), repos, repo_cfg.get('test-on-fork'))  # noqa
         state.title = pull.title
         state.body = suppress_pings(pull.body)
+        state.body = suppress_ignore_block(state.body)
         state.head_ref = pull.head.repo[0] + ':' + pull.head.ref
         state.base_ref = pull.base.ref
         state.set_mergeable(None)

--- a/homu/server.py
+++ b/homu/server.py
@@ -342,7 +342,8 @@ def rollup(user_gh, state, repo_label, repo_cfg, repo):
 
     if base_url:
         pr_list = ','.join(str(x.num) for x in successes)
-        body += '\n\n[Create a similar rollup]({}/queue/{}?prs={})'.format(base_url, repo_label, pr_list)
+        body += ('\n\n[Create a similar rollup]({}/queue/{}?prs={})'
+                .format(base_url, repo_label, pr_list))
 
     try:
         pull = base_repo.create_pull(

--- a/homu/server.py
+++ b/homu/server.py
@@ -342,8 +342,8 @@ def rollup(user_gh, state, repo_label, repo_cfg, repo):
 
     if base_url:
         pr_list = ','.join(str(x.num) for x in successes)
-        body += ('\n\n[Create a similar rollup]({}/queue/{}?prs={})'
-                .format(base_url, repo_label, pr_list))
+        link = '{}/queue/{}?prs={}'.format(base_url, repo_label, pr_list)
+        body += '\n\n[Create a similar rollup]({})'.format(link)
 
     try:
         pull = base_repo.create_pull(

--- a/homu/server.py
+++ b/homu/server.py
@@ -341,7 +341,7 @@ def rollup(user_gh, state, repo_label, repo_cfg, repo):
         base_url = g.cfg['web'].get('canonical_url')
 
     if base_url:
-        pr_list = ','.join(x.num for x in successes)
+        pr_list = ','.join(str(x.num) for x in successes)
         body += '\n\n[Create a similar rollup]({}/queue/{}?prs={})'.format(base_url, repo_label, pr_list)
 
     try:

--- a/homu/tests/test_pr_body.py
+++ b/homu/tests/test_pr_body.py
@@ -1,4 +1,9 @@
-from homu.main import suppress_ignore_block, suppress_pings, IGNORE_BLOCK_START, IGNORE_BLOCK_END
+from homu.main import (
+    suppress_ignore_block,
+    suppress_pings,
+    IGNORE_BLOCK_START,
+    IGNORE_BLOCK_END,
+)
 
 
 def test_suppress_pings_in_PR_body():
@@ -16,11 +21,13 @@ def test_suppress_pings_in_PR_body():
 
     assert suppress_pings(body) == expect
 
+
 def test_suppress_ignore_block_in_PR_body():
-    body = ("Rollup merge\n"
-            "{}\n"
-            "[Create a similar rollup](https://fake.xyz/?prs=1,2,3)\n"
-            "{}"
+    body = (
+        "Rollup merge\n"
+        "{}\n"
+        "[Create a similar rollup](https://fake.xyz/?prs=1,2,3)\n"
+        "{}"
     )
 
     body = body.format(IGNORE_BLOCK_START, IGNORE_BLOCK_END)

--- a/homu/tests/test_pr_body.py
+++ b/homu/tests/test_pr_body.py
@@ -1,4 +1,4 @@
-from homu.main import suppress_pings
+from homu.main import suppress_ignore_block, suppress_pings, IGNORE_BLOCK_START, IGNORE_BLOCK_END
 
 
 def test_suppress_pings_in_PR_body():
@@ -15,3 +15,16 @@ def test_suppress_pings_in_PR_body():
     )
 
     assert suppress_pings(body) == expect
+
+def test_suppress_ignore_block_in_PR_body():
+    body = ("Rollup merge\n"
+            "{}\n"
+            "[Create a similar rollup](https://fake.xyz/?prs=1,2,3)\n"
+            "{}"
+    )
+
+    body = body.format(IGNORE_BLOCK_START, IGNORE_BLOCK_END)
+
+    expect = "Rollup merge\n"
+
+    assert suppress_ignore_block(body) == expect


### PR DESCRIPTION
Add a link to the bottom of generated rollup PR bodies which generates a similar rollup on the queue page. Adds a new `web.base_url` property in the configuration file.

The similar rollup link generator takes all PRs that are successfully merged in a rollup and puts their numbers (comma-delimited) into a query string with the field name `prs`. That query string is parsed by the queue page handler, which passes that information to the templating engine. The templating engine then inserts an appropriate state for each PR's checkbox on the queue page.

Tested functionality on a personal repo. I specifically tested that (a) the query string parsing is fault-tolerant and that (b) the checkbox state calculation does not cause unapproved or try-pending PRs to be checked.

Fixes rust-lang/homu#89.