### PR TITLE
Add vscode-rust to list of bors repositories

### DIFF
--- a/cfg.production.toml
+++ b/cfg.production.toml
@@ -228,6 +228,25 @@ secret = "${HOMU_WEBHOOK_SECRET_RLS}"
 [repo.rls.checks.azure]
 name = "rust-lang.rls"
 
+################
+# vscode-rust  #
+################
+
+[repo.vscode-rust]
+owner = "rust-lang"
+name = "vscode-rust"
+timeout = 1800
+
+# Permissions managed through rust-lang/team
+rust_team = true
+reviewers = []
+try_users = []
+
+[repo.vscode-rust.github]
+secret = "${HOMU_WEBHOOK_SECRET_VSCODE_RUST}"
+[repo.vscode-rust.checks.actions]
+name = "bors build finished"
+
 ###############
 #  crates.io  #
 ###############


### PR DESCRIPTION
Step no. 5 of https://forge.rust-lang.org/infra/docs/bors.html#adding-a-new-repository-to-bors.

Step no. 2: rust-lang/vscode-rust#868
Step no. 3: rust-lang/team#471
Step no. 4: https://github.com/rust-lang/simpleinfra/pull/60