### PR TITLE
Migrate RLS to new GitHub Actions CI

### DIFF
--- a/cfg.production.toml
+++ b/cfg.production.toml
@@ -226,8 +226,8 @@ try_users = []
 
 [repo.rls.github]
 secret = "${HOMU_WEBHOOK_SECRET_RLS}"
-[repo.rls.checks.azure]
-name = "rust-lang.rls"
+[repo.rls.checks.actions]
+name = "bors build finished"
 
 ################
 # vscode-rust  #


### PR DESCRIPTION
Added in https://github.com/rust-lang/rls/commit/91064b901ae27647f0799e9075dcde256160bbdd

r? @pietroalbini 