### PR TITLE
Don't delete the repo's row when un-treeclosing

### DIFF
--- a/homu/main.py
+++ b/homu/main.py
@@ -120,18 +120,13 @@ class Repository:
         self.treeclosed_src = src
         db_query(
             self.db,
-            'DELETE FROM repos where repo = ?',
-            [self.repo_label]
+            '''
+                UPDATE repos
+                SET treeclosed = ?, treeclosed_src = ?
+                WHERE repo = ?
+            ''',
+            [value, src, self.repo_label]
         )
-        if value > 0:
-            db_query(
-                self.db,
-                '''
-                    INSERT INTO repos (repo, treeclosed, treeclosed_src)
-                    VALUES (?, ?, ?)
-                ''',
-                [self.repo_label, value, src]
-            )
 
     def __lt__(self, other):
         return self.gh < other.gh


### PR DESCRIPTION
I'm creating this as draft because it's very possible the old code is necessary
for something that I don't know of. Either way, it's quite confusing!

*See the [discussion on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/How.20to.20unclose.20the.20tree.3F/near/218949386).*
