### PR TITLE
Parse `delegate=` while stripping `@`

### DIFF
--- a/homu/parse_issue_comment.py
+++ b/homu/parse_issue_comment.py
@@ -45,7 +45,7 @@ class IssueCommentCommand:
     @classmethod
     def delegate(cls, delegate_to):
         command = cls('delegate')
-        command.delegate_to = delegate_to
+        command.delegate_to = delegate_to.lstrip('@')
         return command
 
     @classmethod

--- a/homu/tests/test_parse_issue_comment.py
+++ b/homu/tests/test_parse_issue_comment.py
@@ -213,6 +213,21 @@ def test_delegate_equals():
     assert command.delegate_to == 'jill'
 
 
+def test_delegate_equals_at_user():
+    """
+    @bors delegate=@{username}
+    """
+
+    author = "jack"
+    body = "@bors delegate=@jill"
+    commands = parse_issue_comment(author, body, commit, "bors")
+
+    assert len(commands) == 1
+    command = commands[0]
+    assert command.action == 'delegate'
+    assert command.delegate_to == 'jill'
+
+
 def test_delegate_minus():
     """
     @bors delegate-


### PR DESCRIPTION
Found a mistake in https://github.com/rust-lang/rust/pull/79639#issuecomment-741743749.
This should be parsed as same as `r=`, I think.