### PR TITLE
css: Collapse Head Ref Collumn

### DIFF
--- a/homu/html/queue.html
+++ b/homu/html/queue.html
@@ -28,7 +28,7 @@
             table { border-collapse: collapse; }
             td, th { border-bottom: 1px solid #ddd; padding: 5px 6px; font-size: 13px; text-align: left; vertical-align: baseline; }
             tr:nth-child(even) { background: #eee; }
-
+            #queue tr > td:nth-child(8) { word-break: break-all; }
             a {
                 text-decoration: none;
             }


### PR DESCRIPTION
The head ref takes up alot of space, due to some [very long](https://github.com/rust-lang/rust/pull/79746) branch names. This means the table overflows, and you need to scroll to see the rollup status. 

By breaking the words, it's much nicer.

Before:

![image](https://user-images.githubusercontent.com/28781354/108855575-124c1700-75e1-11eb-832b-4318e1006e2e.png)

After:

![image](https://user-images.githubusercontent.com/28781354/108855737-360f5d00-75e1-11eb-8621-e6d02bf56712.png)
