### PR TITLE
Do not include PR's title in a rollup PR

### DIFF
--- a/homu/server.py
+++ b/homu/server.py
@@ -343,10 +343,10 @@ def rollup(user_gh, state, repo_label, repo_cfg, repo):
 
     body = 'Successful merges:\n\n'
     for x in successes:
-        body += ' - #{} ({})\n'.format(x.num, x.title)
+        body += ' - #{}\n'.format(x.num)
     body += '\nFailed merges:\n\n'
     for x in failures:
-        body += ' - #{} ({})\n'.format(x.num, x.title)
+        body += ' - #{}\n'.format(x.num)
     body += '\nr? @ghost\n@rustbot modify labels: rollup'
 
     # Set web.base_url in cfg to enable


### PR DESCRIPTION
GitHub already shows the title so there's no need to include the title:
![image](https://user-images.githubusercontent.com/43851243/124699906-513e9180-df1e-11eb-88f4-582372fe233b.png)
