### PR TITLE
Avoid failing when issue.body is None

### DIFF
--- a/homu/main.py
+++ b/homu/main.py
@@ -372,7 +372,7 @@ class PullReqState:
         issue = self.get_repo().issue(self.num)
 
         self.title = issue.title
-        self.body = suppress_pings(issue.body)
+        self.body = suppress_pings(issue.body or "")
         self.body = suppress_ignore_block(self.body)
 
     def fake_merge(self, repo_cfg):


### PR DESCRIPTION
This appears to be causing a failure to refresh queues in production, though we have no concrete evidence issue.body is actually None (just that it's not a string...).

