### PR TITLE
Add links to bors-related things

### DIFF
--- a/homu/html/index.html
+++ b/homu/html/index.html
@@ -36,6 +36,18 @@
 
             <h1>Homu</h1>
 
+            <p>
+                <a href="https://github.com/rust-lang/homu">Homu</a> is a bot that integrates with GitHub and your
+                favorite continuous integration service such as Travis CI, Appveyor or Buildbot.
+            </p>
+
+            <p>
+                For instance, <a href="https://forge.rust-lang.org/infra/docs/bors.html">in the Rust project</a>
+                Homu runs as the GitHub user <a href="https://github.com/bors">@bors</a>. Note: there is a similar
+                project called Bors-NG at <a href="https://bors.tech/">https://bors.tech/</a>, but that is not what runs
+                on the Rust project's @bors GitHub account.
+            </p>
+
             <h2>Repositories</h2>
 
             <ul class="repos">


### PR DESCRIPTION
On reaching the page at https://bors.rust-lang.org/, it's not immediately clear what Homu is or what its relationship is to the bors
GitHub bot or the Bors-NG project. Add some verbiage and links to make the relationships clearer.