### PR TITLE
Drop timeout from 4.25 hours to 3 hours

### DIFF
--- a/cfg.production.toml
+++ b/cfg.production.toml
@@ -31,7 +31,7 @@ remove_path_prefixes = ["homu"]
 [repo.rust]
 owner = "rust-lang"
 name = "rust"
-timeout = 15300
+timeout = 10800
 
 # Permissions managed through rust-lang/team
 rust_team = true


### PR DESCRIPTION
Our maximum time per builder is roughly 2.75 hours right now, so a 3 hour
timeout should be relatively safe and provide a better stopping point if we're
not going to finish at all.

Max time over last 12 commits; top 5 builders:

![image](https://user-images.githubusercontent.com/5047365/153666874-b39c40a5-dfd5-457f-afcc-15d6c97cb858.png)
