### PR TITLE
Avoid attribute error, always push state to failures

### DIFF
--- a/homu/server.py
+++ b/homu/server.py
@@ -315,7 +315,7 @@ def rollup(user_gh, state, repo_label, repo_cfg, repo):
 
     for state in rollup_states:
         if base_ref != state.base_ref:
-            failures.append(state.num)
+            failures.append(state)
             continue
 
         state.body = suppress_pings(state.body or "")


### PR DESCRIPTION
Seeing reports of this error on some rollups:

```
Traceback (most recent call last):
File "/usr/local/bin/bottle.py", line 868, in _handle
return route.call(**args)
File "/usr/local/bin/bottle.py", line 1748, in wrapper
rv = callback(*a, **ka)
File "/src/homu/server.py", line 273, in callback
return rollup(user_gh, state, repo_label, repo_cfg, repo)
File "/src/homu/server.py", line 349, in rollup
body += ' - #{} ({})\n'.format(x.num, x.title)
AttributeError: 'int' object has no attribute 'num'
```