### PR TITLE
Remove FreeBSD 11 from libc CI

### DIFF
--- a/cfg.production.toml
+++ b/cfg.production.toml
@@ -150,8 +150,6 @@ secret = "${HOMU_WEBHOOK_SECRET_LIBC}"
 
 [repo.libc.checks.actions]
 name = "bors build finished"
-[repo.libc.checks.cirrus-freebsd-11]
-name = "stable x86_64-unknown-freebsd-11"
 [repo.libc.checks.cirrus-freebsd-12]
 name = "nightly x86_64-unknown-freebsd-12"
 [repo.libc.checks.cirrus-freebsd-13]


### PR DESCRIPTION
FreeBSD 11 is EOL and recently ceased hosting packages for that version of the OS, which is causing libc CI to fail.