### PR TITLE
Add a link to the queue when posting approval for PR

### DIFF
--- a/homu/comments.py
+++ b/homu/comments.py
@@ -28,7 +28,7 @@ class Approved(Comment):
         super().__init__(**args)
         self.bot = bot
 
-    params = ["sha", "approver"]
+    params = ["sha", "approver", "queue"]
 
     def render(self):
         # The comment here is required because Homu wants a full, unambiguous,
@@ -37,11 +37,13 @@ class Approved(Comment):
         # reloads and another commit has been pushed since the approval.
         message = ":pushpin: Commit {sha} has been " + \
             "approved by `{approver}`\n\n" + \
+            "It is now in the [queue]({queue}) for this repository.\n\n" + \
             "<!-- @{bot} r={approver} {sha} -->"
         return message.format(
             sha=self.sha,
             approver=self.approver,
-            bot=self.bot
+            bot=self.bot,
+            queue=self.queue
         )
 
 

--- a/homu/main.py
+++ b/homu/main.py
@@ -603,6 +603,8 @@ def parse_commands(body, username, user_id, repo_label, repo_cfg, state,
                         sha=state.head_sha,
                         approver=approver,
                         bot=my_username,
+                        queue="https://bors.rust-lang.org/homu/queue/{}"
+                        .format(repo_label)
                     ))
                     treeclosed, treeclosed_src = state.blocked_by_closed_tree()
                     if treeclosed:

--- a/homu/tests/test_parse_issue_comment.py
+++ b/homu/tests/test_parse_issue_comment.py
@@ -87,8 +87,9 @@ def test_hidden_r_equals():
     author = "bors"
     body = """
     :pushpin: Commit {0} has been approved by `jack`
+    It is now in the [queue]({1}) for this repository.\n\n
     <!-- @bors r=jack {0} -->
-    """.format(commit)
+    """.format(commit, "rust")
 
     commands = parse_issue_comment(author, body, commit, "bors")
 


### PR DESCRIPTION
This should help new users with knowing what to do after an r+ has been posted
(i.e., that the PR is in queue).

Haven't tested this yet, probably easiest to just merge. Will run CI tests -- looks like we have a test case for the specific text here.