### PR TITLE
treat iffy and never PRs the same for queue order

### DIFF
--- a/homu/main.py
+++ b/homu/main.py
@@ -199,7 +199,9 @@ class PullReqState:
             1 if self.mergeable is False else 0,
             0 if self.approved_by else 1,
             -self.priority,
-            self.rollup,
+            # Cap `rollup` below at -1 (the value for iffy), so iffy and never
+            # are treated the same.
+            max(self.rollup, -1),
             self.num,
         ]
 


### PR DESCRIPTION
Based on [this discussion](https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/rollup.3Diffy.20vs.20never.3F), iffy PRs currently have to wait forever since they will only be automatically tried once all the rollup=never PRs have laded. So maybe let's treat rollup-iffy and rollup=never the same for queue priority?