### PR TITLE
Reduce libc timeout to 1.5 hours

### DIFF
--- a/cfg.production.toml
+++ b/cfg.production.toml
@@ -135,7 +135,7 @@ unless = ['S-blocked', 'S-waiting-on-review']
 [repo.libc]
 owner = "rust-lang"
 name = "libc"
-timeout = 9000
+timeout = 5400
 
 # Permissions managed through rust-lang/team
 rust_team = true


### PR DESCRIPTION
I've been investigating the weird Android emulator behavior that gets stuck at some point and reducing timeout helps to debug. 

The value is determined by checking the recent jobs are finished around 1h10m on the libc repo: https://github.com/rust-lang/libc/actions/workflows/bors.yml?query=is%3Asuccess

Signed-off-by: Yuki Okushi <jtitor@2k36.org>