### PR TITLE
feat: Remove duplicated PR titles

### DIFF
--- a/homu/server.py
+++ b/homu/server.py
@@ -343,10 +343,10 @@ def rollup(user_gh, state, repo_label, repo_cfg, repo):
 
     body = 'Successful merges:\n\n'
     for x in successes:
-        body += ' - #{} ({})\n'.format(x.num, x.title)
+        body += ' - #{}\n'.format(x.num)
     body += '\nFailed merges:\n\n'
     for x in failures:
-        body += ' - #{} ({})\n'.format(x.num, x.title)
+        body += ' - #{}\n'.format(x.num)
     body += '\nr? @ghost\n@rustbot modify labels: rollup'
 
     # Set web.base_url in cfg to enable


### PR DESCRIPTION
GitHub will automatically render `#123` into its title, so we don't need to repeat the title.