### PR TITLE
Remove `squash` from command list

### DIFF
--- a/homu/html/index.html
+++ b/homu/html/index.html
@@ -66,8 +66,6 @@
                 <li><code>rollup</code>: Mark the PR as likely to merge without issue, short for <code>rollup=always</code></li>
                 <li><code>rollup-</code>: Unmark the PR as <code>rollup</code>.</li>
                 <li><code>rollup=maybe|always|iffy|never</code>: Mark the PR as "always", "maybe", "iffy", and "never" rollup-able.</li>
-                <li><code>squash</code>: Squash all commits into one just before performing the merge.</li>
-                <li><code>squash-</code>: Do not squash commits before merging.</li>
                 <li><code>retry</code>: Signal that the PR is not bad, and should be retried by buildbot.</li>
                 <li><code>try</code>: Request that the PR be tested by buildbot, without accepting it.</li>
                 <li><code>force</code>: Stop all the builds on the configured builders, and proceed to the next PR.</li>

--- a/homu/parse_issue_comment.py
+++ b/homu/parse_issue_comment.py
@@ -236,10 +236,14 @@ def parse_issue_comment(username, body, sha, botname, hooks=[]):
             commands.append(IssueCommentCommand.rollup(rollup_value))
 
         elif word == 'squash':
-            commands.append(IssueCommentCommand.squash())
+            # Squash is broken, prevent its usage.
+            # commands.append(IssueCommentCommand.squash())
+            pass
 
         elif word == 'squash-':
-            commands.append(IssueCommentCommand.unsquash())
+            # Squash is broken, prevent its usage.
+            # commands.append(IssueCommentCommand.unsquash())
+            pass
 
         elif word == 'force':
             commands.append(IssueCommentCommand.force())


### PR DESCRIPTION
Squash is hopelessly broken and should never be used. (#136, #181).