### PR TITLE
Prevent `@bors try-` from being used

### DIFF
--- a/homu/parse_issue_comment.py
+++ b/homu/parse_issue_comment.py
@@ -229,7 +229,9 @@ def parse_issue_comment(username, body, sha, botname, hooks=[]):
             commands.append(IssueCommentCommand.try_())
 
         elif word == 'try-':
-            commands.append(IssueCommentCommand.untry())
+            # Try- is broken, prevent its usage.
+            # commands.append(IssueCommentCommand.untry())
+            pass
 
         elif word in WORDS_TO_ROLLUP:
             rollup_value = WORDS_TO_ROLLUP[word]

--- a/homu/tests/test_parse_issue_comment.py
+++ b/homu/tests/test_parse_issue_comment.py
@@ -280,9 +280,7 @@ def test_try_minus():
     body = "@bors try-"
     commands = parse_issue_comment(author, body, commit, "bors")
 
-    assert len(commands) == 1
-    command = commands[0]
-    assert command.action == 'untry'
+    assert len(commands) == 0
 
 
 def test_rollup():


### PR DESCRIPTION
`try-` breaks the PR in weird ways that we would rather not see.

For an example where it broke things, see here: https://github.com/rust-lang/rust/pull/105190#issuecomment-1345400213. After that comment, chaos ensured and bors started displaying the try build as a merge.