### PR TITLE
Add more instructions when delegating

### DIFF
--- a/homu/comments.py
+++ b/homu/comments.py
@@ -69,8 +69,16 @@ class Delegated(Comment):
     params = ["delegator", "delegate"]
 
     def render(self):
-        message = ':v: @{} can now approve this pull request'
-        return message.format(self.delegate)
+        message = \
+            ':v: @{delegate}, you can now approve this pull request!\n\n' + \
+            'If @{delegator} told you to "`r=me`" after making some ' + \
+            'further change, please make that change, then do ' + \
+            '`@{bot} r=@{delegator}`'
+        return message.format(
+            delegate=self.delegate,
+            bot=self.bot,
+            delegator=self.delegator
+        )
 
 
 class BuildStarted(Comment):


### PR DESCRIPTION
People often don't know what to do when someone does `@bors delegate+` to them.
Add instructions.
