### PR TITLE
Fix delegate comment

### DIFF
--- a/homu/comments.py
+++ b/homu/comments.py
@@ -66,6 +66,15 @@ class ApprovalIgnoredWip(Comment):
 
 
 class Delegated(Comment):
+    def __init__(self, bot=None, **args):
+        # Because homu needs to leave a comment for the delegated person,
+        # we need to know the correct botname to use. However, we don't want to
+        # save that botname in our state JSON. So we need a custom constructor
+        # to grab the botname and delegate the rest of the keyword args to the
+        # Comment constructor.
+        super().__init__(**args)
+        self.bot = bot
+
     params = ["delegator", "delegate"]
 
     def render(self):

--- a/homu/main.py
+++ b/homu/main.py
@@ -664,7 +664,8 @@ def parse_commands(body, username, user_id, repo_label, repo_cfg, state,
             if realtime:
                 state.add_comment(comments.Delegated(
                     delegator=username,
-                    delegate=state.delegate
+                    delegate=state.delegate,
+                    bot=my_username
                 ))
 
         elif command.action == 'undelegate':
@@ -684,7 +685,8 @@ def parse_commands(body, username, user_id, repo_label, repo_cfg, state,
             if realtime:
                 state.add_comment(comments.Delegated(
                     delegator=username,
-                    delegate=state.delegate
+                    delegate=state.delegate,
+                    bot=my_username
                 ))
 
         elif command.action == 'retry' and realtime:


### PR DESCRIPTION
This PR [fixes the crash](https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/bors.20ignoring.20.60delegate.2B.60.3F) reported when delegating the approval to someone.

The fix use the same approach used by the `Approved` comment, that is getting the bot name at the creation of the comment.

r? @jyn514 