### PR TITLE
Remove measureme configuration

### DIFF
--- a/cfg.production.toml
+++ b/cfg.production.toml
@@ -326,27 +326,6 @@ secret = "${HOMU_WEBHOOK_SECRET_MIRI}"
 [repo.miri.checks.actions]
 name = "bors build finished"
 
-###############
-#  MEASUREME  #
-###############
-
-[repo.measureme]
-owner = "rust-lang"
-name = "measureme"
-timeout = 7200
-
-# Permissions managed through rust-lang/team
-rust_team = true
-reviewers = []
-try_users = []
-
-[repo.measureme.branch]
-auto = "auto"
-[repo.measureme.github]
-secret = "${HOMU_WEBHOOK_SECRET_MEASUREME}"
-[repo.measureme.checks.actions]
-name = "bors build finished"
-
 ############
 #  Crater  #
 ############


### PR DESCRIPTION
Since bors won't be used for `measureme` anymore, I think that we should remove it from here, to keep the list on https://bors.rust-lang.org/ updated.

If this is merged, someone with the necessary permissions should probably go ahead and remove the bors webhooks from https://github.com/rust-lang/measureme.