### PR TITLE
Fix a TypeError in debug statement

### DIFF
--- a/homu/server.py
+++ b/homu/server.py
@@ -1050,7 +1050,7 @@ def redirect_to_canonical_host():
             redirect_url = redirect_url._replace(path="/")
 
     if request_url != redirect_url:
-        print("redirecting original=" + request_url + " to new=" + redirect_url) # noqa
+        print("redirecting original=" + request_url.geturl() + " to new=" + redirect_url.geturl())  # noqa
         redirect(urllib.parse.urlunparse(redirect_url), 301)
 
 


### PR DESCRIPTION
The debug statement that was added to print the redirect URLs fails in production with the following error:

```
TypeError: can only concatenate str (not "ParseResult") to str
```

`geturl` returns the URL as a str, which we can then concatenate with the debug statement.