### PR TITLE
Note that PR review comments should be enabled in webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ the name of the repository you are configuring homu for.
    - Content type: `application/json`
    - Secret: The same as `repo.NAME.github.secret` in `cfg.toml`
    - Events: click "Let me select individual events", then pick
-       `Issue comments`, `Pull requests`, `Pushes`, `Statuses`, `Check runs`
+       `Issue comments`, `Pull requests`, `Pushes`, `Statuses`, `Check runs` and `Pull request review comments`
 
 6. Add a Webhook to your continuous integration service, if necessary. You don't
    need this if using Travis/Appveyor.


### PR DESCRIPTION
We specifically check review comments: https://github.com/rust-lang/homu/blob/f652a9e7ecc42a1a590f48e96d9d34df4596aedb/homu/main.py#L1628-L1644

But the README doesn't recommend enabling this, so PR review comments are only checked on resynchronization. Ticking this box makes it work.
