### PR TITLE
Escape auto-linked GitHub usernames more precisely

### DIFF
--- a/homu/tests/test_pr_body.py
+++ b/homu/tests/test_pr_body.py
@@ -7,16 +7,58 @@ from homu.main import (
 
 
 def test_suppress_pings_in_PR_body():
+    # This behavior can be verified by pasting the text into a Markdown editor
+    # on Github and checking which usernames are auto-linked.
+
     body = (
-        "r? @matklad\n"         # should escape
-        "@bors r+\n"            # shouldn't
-        "mail@example.com"      # shouldn't
+        # Should escape:
+        "r? @matklad\n"
+        "@bors r+\n"
+        "@a\n"  # Minimum length
+        "@abcdefghijklmnopqrstuvwxyzabcdefghijklm\n"  # Maximum length
+        "@user. @user, @user; @user? @user!\n"
+        "@user@user\n"  # Only the first is auto-linked
+        "@user/@user/@user\n"  # Only the last is auto-linked
+        "@@user\n"
+        "/@user\n"
+        "-@user\n"
+        "@user--name\n"  # Auto-linked, despite being an invalid username
+        "@user-\n"  # Auto-linked, despite being an invalid username
+        "`@user`\n"  # Code block handling is not implemented
+
+        # Shouldn't escape:
+        "mail@example.com\n"
+        "@abcdefghijklmnopqrstuvwxyzabcdefghijklmo\n"  # Over maximum length
+        "text@user\n"
+        "@-\n"
+        "@-user\n"
+        "@user/\n"
+        "@user_\n"
+        "_@user\n"
     )
 
     expect = (
         "r? `@matklad`\n"
         "`@bors` r+\n"
-        "mail@example.com"
+        "`@a`\n"
+        "`@abcdefghijklmnopqrstuvwxyzabcdefghijklm`\n"
+        "`@user`. `@user`, `@user`; `@user`? `@user`!\n"
+        "`@user`@user\n"
+        "@user/@user/`@user`\n"
+        "@`@user`\n"
+        "/`@user`\n"
+        "-`@user`\n"
+        "`@user--name`\n"
+        "`@user-`\n"
+        "``@user``\n"
+        "mail@example.com\n"
+        "@abcdefghijklmnopqrstuvwxyzabcdefghijklmo\n"
+        "text@user\n"
+        "@-\n"
+        "@-user\n"
+        "@user/\n"
+        "@user_\n"
+        "_@user\n"
     )
 
     assert suppress_pings(body) == expect


### PR DESCRIPTION
More precisely match how GitHub auto-links usernames when escaping usernames to suppress pings.

Perhaps most noticeably, this now keeps punctuation outside of the escaped username.

You can verify that this matches GitHub's behavior by copying the test string (with strings concatenated and `\n`s resolved, of course) into a Markdown editor on GitHub and comparing what is auto-linked when rendered.

Improves upon https://github.com/rust-lang/homu/pull/100.