### PR TITLE
Revert rollup button style change, and move sync button and its warning message to bottom of page

### DIFF
--- a/homu/html/queue.html
+++ b/homu/html/queue.html
@@ -122,25 +122,6 @@
                 color: #00f;
             }
 
-            /* Make the rollup button vs sync button clear distinct, because sync requires some elaborate procedure. */
-            button#expand-rollup {
-                background-color: darkcyan;
-                border: 2px solid #000000;
-                border-radius: 4px;
-                box-shadow: rgba(0, 0, 0, .1) 0 2px 4px 0;
-                box-sizing: border-box;
-                color: #fff;
-                font-size: 16px;
-                font-weight: 400;
-                padding: 10px 25px;
-                text-align: center;
-            }
-
-            button#expand-rollup:hover {
-                box-shadow: rgba(0, 0, 0, .15) 0 3px 9px 0;
-                transform: translateY(-2px);
-            }
-
             button#synch {
                 background-color: red;
                 border: 2px solid #000000;

--- a/homu/html/queue.html
+++ b/homu/html/queue.html
@@ -150,10 +150,7 @@
 
         <p>
             <button type="button" id="expand-rollup">Create a rollup</button>
-            <button type="button" id="synch">Synchronize</button>
         </p>
-
-        <p style="color: #ff6347">Caution: Synchronization has some caveats. Please follow the steps described in <a href="https://forge.rust-lang.org/infra/docs/bors/queue-resync.html"><i>Fixing inconsistencies in the bors queue</i></a>.</p>
 
         <div id="actual-rollup" class="hide">
             <p>This will create a new pull request consisting of <span id="checkbox-count">0</span> PRs.</p>
@@ -229,6 +226,11 @@
         </table>
 
         <p><a href="../retry_log/{{repo_label}}">Open retry log</a></p>
+
+        <p>
+            <button type="button" id="synch">Synchronize</button>
+        </p>
+        <p style="color: #ff6347">Caution: Synchronization has some caveats. Please follow the steps described in <a href="https://forge.rust-lang.org/infra/docs/bors/queue-resync.html"><i>Fixing inconsistencies in the bors queue</i></a>.</p>
 
         <script src="../assets/jquery.min.js"></script>
         <script src="../assets/jquery.dataTables.min.js"></script>


### PR DESCRIPTION
The style changes turned out to be more disruptive for the rollup happy path usages, as reported in https://github.com/rust-lang/homu/pull/231#issuecomment-2868297708.

### Preview

(Ignore the templates) Notice that:

- The rollup button is reverted to old non-intrusive style.
- The sync button is still scary, but the sync button and the warning message is now moved to bottom of page.

![Screenshot 2025-05-10 162203](https://github.com/user-attachments/assets/7926f13c-4911-47c6-bcee-522a08fe3382)


cc @Zalathar
r? @pietroalbini 