### PR TITLE
Move bors CI jobs from rust-lang-ci to rust-lang

### DIFF
--- a/cfg.production.toml
+++ b/cfg.production.toml
@@ -38,10 +38,6 @@ rust_team = true
 reviewers = []
 try_users = []
 
-[repo.rust.test-on-fork]
-owner = "rust-lang-ci"
-name = "rust"
-
 [repo.rust.github]
 secret = "${HOMU_WEBHOOK_SECRET_RUST}"
 [repo.rust.checks.actions]


### PR DESCRIPTION
Needed for https://github.com/rust-lang/infra-team/issues/188.

Warning: this shouldn't be merged until we get some t-infra[-admins] people to be ready to put out potential fires.