### PR TITLE
Fix pinned dependencies on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Ensure the code passes lints
         run: flake8 homu/
 
+      - name: Preinstall pinned Python dependencies
+        run: pip install -r requirements.txt
+
       - name: Install homu on the builder
         run: pip install -e .
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ idna==3.6
 Jinja2==3.1.3
 MarkupSafe==2.1.5
 pip==20.0.2
+pluggy==1.5.0
 requests==2.31.0
 retrying==1.3.4
 setuptools==45.2.0

--- a/setup.py
+++ b/setup.py
@@ -20,10 +20,10 @@ setup(
         'retrying',
     ],
     setup_requires=[
-        'pytest-runner',
+        'pytest-runner<8',
     ],
     tests_require=[
-        'pytest',
+        'pytest<8',
     ],
     package_data={
         'homu': [


### PR DESCRIPTION
The dependencies have installed pluggy 1.6.0, which was failing on Python 3.8.

I would like to land these changes separately, because if we will need to revert https://github.com/rust-lang/homu/pull/233, then we don't want CI to fail.. :)